### PR TITLE
Removed separate switch case for md and markdown files

### DIFF
--- a/src/Cleaver.php
+++ b/src/Cleaver.php
@@ -35,8 +35,6 @@ class Cleaver
                     $compiler = new JsonCompiler($contentFile);
                     break;
                 case 'md':
-                    $compiler = new MarkdownCompiler($contentFile);
-                    break;
                 case 'markdown':
                     $compiler = new MarkdownCompiler($contentFile);
                     break;


### PR DESCRIPTION
Only a small change but there is no need to have separate cases for each extension here as they both execute the exact same code.