### PR TITLE
Feature/1.4

### DIFF
--- a/cleaver
+++ b/cleaver
@@ -7,5 +7,5 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
 }
 
-$cleaver = new Cleaver();
+$cleaver = new Cleaver(dirname(__FILE__));
 $cleaver->build();

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "codedungeon/php-cli-colors": "~1.0",
         "ext-json": "*",
         "erusev/parsedown": "^1.7",
-        "symfony/filesystem": "^4.4"
+        "symfony/filesystem": "^4.4",
+        "tightenco/collect": "^7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08b0657b5935a8e900c7e6800f00534a",
+    "content-hash": "c800867587ed57bc145df53498a5ad27",
     "packages": [
         {
             "name": "codedungeon/php-cli-colors",
@@ -1119,6 +1119,131 @@
                 "standards"
             ],
             "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "3a37aeb1132d1035536d3d6aa9cb06c2ff9355e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3a37aeb1132d1035536d3d6aa9cb06c2ff9355e9",
+                "reference": "3a37aeb1132d1035536d3d6aa9cb06c2ff9355e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^2.4|^3.0"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2020-02-26T22:30:10+00:00"
+        },
+        {
+            "name": "tightenco/collect",
+            "version": "v7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tightenco/collect.git",
+                "reference": "306a4def08c9781ff74fcf1e012f22cbf8686348"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/306a4def08c9781ff74fcf1e012f22cbf8686348",
+                "reference": "306a4def08c9781ff74fcf1e012f22cbf8686348",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "nesbot/carbon": "^2.23.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Collect/Support/helpers.php",
+                    "src/Collect/Support/alias.php"
+                ],
+                "psr-4": {
+                    "Tightenco\\Collect\\": "src/Collect"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylorotwell@gmail.com"
+                }
+            ],
+            "description": "Collect - Illuminate Collections as a separate package.",
+            "keywords": [
+                "collection",
+                "laravel"
+            ],
+            "time": "2020-03-09T16:52:33+00:00"
         }
     ],
     "packages-dev": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,9 +1206,9 @@
             }
         },
         "acorn": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-            "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+            "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
             "dev": true
         },
         "after": {
@@ -1962,6 +1962,26 @@
                 "yargs": "6.4.0"
             },
             "dependencies": {
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
                 "micromatch": {
                     "version": "3.1.10",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1981,7 +2001,21 @@
                         "regex-not": "^1.0.0",
                         "snapdragon": "^0.8.1",
                         "to-regex": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.3",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                            "dev": true
+                        }
                     }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
                 }
             }
         },
@@ -2345,30 +2379,118 @@
             "dev": true
         },
         "chokidar": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-            "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+            "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
             "dev": true,
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.1",
-                "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.3",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^3.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.2.1",
-                "upath": "^1.1.1"
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.3.0"
             },
             "dependencies": {
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+                    "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+                    "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
                 "normalize-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
                     "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
                     "dev": true
+                },
+                "readdirp": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+                    "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+                    "dev": true,
+                    "requires": {
+                        "picomatch": "^2.0.7"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
                 }
             }
         },
@@ -2452,6 +2574,17 @@
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
                 "wrap-ansi": "^2.0.0"
+            }
+        },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
             }
         },
         "coa": {
@@ -3351,6 +3484,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
             "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+            "dev": true
+        },
+        "de-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+            "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
             "dev": true
         },
         "debug": {
@@ -6586,9 +6725,9 @@
             "dev": true
         },
         "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
         "laravel-mix": {
@@ -6648,6 +6787,26 @@
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
                     "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
                 },
                 "cliui": {
                     "version": "4.1.0",
@@ -6709,6 +6868,12 @@
                     "requires": {
                         "invert-kv": "^2.0.0"
                     }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
                 },
                 "os-locale": {
                     "version": "3.1.0",
@@ -7279,9 +7444,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "minipass": {
@@ -8124,6 +8289,12 @@
                 "safe-buffer": "^5.0.1",
                 "sha.js": "^2.4.8"
             }
+        },
+        "picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
         },
         "pify": {
             "version": "2.3.0",
@@ -11112,6 +11283,64 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
         },
+        "sass": {
+            "version": "1.26.3",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.3.tgz",
+            "integrity": "sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==",
+            "dev": true,
+            "requires": {
+                "chokidar": ">=2.0.0 <4.0.0"
+            }
+        },
+        "sass-loader": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+            "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "loader-utils": "^1.2.3",
+                "neo-async": "^2.6.1",
+                "schema-utils": "^2.6.1",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+                    "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+                    "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+                    "dev": true
+                },
+                "schema-utils": {
+                    "version": "2.6.5",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
+                    "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.12.0",
+                        "ajv-keywords": "^3.4.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -11286,6 +11515,15 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
+            }
+        },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
             }
         },
         "shebang-command": {
@@ -12978,6 +13216,16 @@
                 "loader-utils": "^1.0.2"
             }
         },
+        "vue-template-compiler": {
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+            "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
+            "dev": true,
+            "requires": {
+                "de-indent": "^1.0.2",
+                "he": "^1.1.0"
+            }
+        },
         "vue-template-es2015-compiler": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
@@ -12993,6 +13241,34 @@
                 "chokidar": "^2.0.2",
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0"
+            },
+            "dependencies": {
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                }
             }
         },
         "wbuf": {
@@ -13483,6 +13759,26 @@
                     "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
                 },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
                 "cliui": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -13560,6 +13856,12 @@
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
                     "dev": true
                 },
                 "opn": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     },
     "devDependencies": {
         "bootstrap": "^4.4.1",
-        "popper.js": "1.16.0",
         "browser-sync": "^2.26.7",
         "browser-sync-webpack-plugin": "^2.0.1",
         "cross-env": "^3.2.3",
@@ -20,8 +19,12 @@
         "mix-tailwindcss": "^1.2.0",
         "node-cmd": "^3.0.0",
         "on-build-webpack": "^0.1.0",
+        "popper.js": "1.16.0",
+        "sass": "^1.26.3",
+        "sass-loader": "^8.0.2",
         "tailwindcss": "^1.1.4",
         "vue": "^2.6.10",
+        "vue-template-compiler": "^2.6.11",
         "webpack-watch": "^0.2.0"
     }
 }

--- a/src/Cleaver.php
+++ b/src/Cleaver.php
@@ -5,6 +5,7 @@ namespace Aschmelyun\Cleaver;
 use Aschmelyun\Cleaver\Compilers\JsonCompiler;
 use Aschmelyun\Cleaver\Compilers\MarkdownCompiler;
 use Aschmelyun\Cleaver\Engines\BladeEngine;
+use Aschmelyun\Cleaver\Engines\ContentEngine;
 use Aschmelyun\Cleaver\Engines\FileEngine;
 use Aschmelyun\Cleaver\Output\Display;
 
@@ -13,18 +14,21 @@ class Cleaver
 
     private $buildTime;
     private $buildAmount = 0;
+    private $basePath;
 
-    public function __construct()
+    public function __construct(?string $basePath = null)
     {
         $this->buildTime['start'] = microtime(true);
         $this->buildTime['end'] = 0;
+
+        $this->basePath = $basePath ? $basePath : dirname(__FILE__, 2);
     }
 
     public function build(): void
     {
-        $blade = new BladeEngine();
+        $blade = new BladeEngine($this->basePath);
 
-        $fileEngine = new FileEngine();
+        $fileEngine = new FileEngine($this->basePath);
         $fileEngine->cleanOutputDir();
 
         foreach($fileEngine->getContentFiles() as $contentFile) {
@@ -44,6 +48,7 @@ class Cleaver
             }
 
             if($compiler && $compiler->checkFormatting()) {
+                $compiler->json->content = ContentEngine::generateCollection($fileEngine);
                 $blade->save($blade->render($compiler->json));
                 echo Display::success($compiler->file . ' saved successfully.');
 

--- a/src/Compilers/JsonCompiler.php
+++ b/src/Compilers/JsonCompiler.php
@@ -3,6 +3,7 @@
 namespace Aschmelyun\Cleaver\Compilers;
 
 use Aschmelyun\Cleaver\Engines\FileEngine;
+use Symfony\Component\Finder\SplFileInfo;
 
 class JsonCompiler
 {
@@ -10,12 +11,12 @@ class JsonCompiler
     public $json;
     public $file;
 
-    public function __construct(string $file)
+    public function __construct(SplFileInfo $file)
     {
         $this->file = $file;
 
         $this->json = json_decode(
-            file_get_contents(FileEngine::contentDir() . $file)
+            $file->getContents()
         );
 
         $this->json->mix = FileEngine::mixManifestData();

--- a/src/Compilers/MarkdownCompiler.php
+++ b/src/Compilers/MarkdownCompiler.php
@@ -3,6 +3,7 @@
 namespace Aschmelyun\Cleaver\Compilers;
 
 use Aschmelyun\Cleaver\Engines\FileEngine;
+use Symfony\Component\Finder\SplFileInfo;
 
 class MarkdownCompiler
 {
@@ -10,12 +11,12 @@ class MarkdownCompiler
     public $json;
     public $file;
 
-    public function __construct(string $file)
+    public function __construct(SplFileInfo $file)
     {
         $this->file = $file;
 
         $this->json = $this->parseMarkdown(
-            file_get_contents(FileEngine::contentDir() . $file)
+            $file->getContents()
         );
 
         $this->json->mix = FileEngine::mixManifestData();

--- a/src/Engines/BladeEngine.php
+++ b/src/Engines/BladeEngine.php
@@ -7,14 +7,19 @@ use Philo\Blade\Blade;
 class BladeEngine
 {
 
-    public $viewsDir = __DIR__ . '/../../resources/views';
-    public $cacheDir = __DIR__ . '/../../cache';
+    public $viewsDir;
+    public $cacheDir;
 
     private $blade;
     private $data;
 
-    public function __construct()
+    public function __construct(?string $basePath = null)
     {
+        $basePath = $basePath ? $basePath : dirname(__FILE__, 3);
+
+        $this->viewsDir = $basePath . '/resources/views';
+        $this->cacheDir = $basePath . '/cache';
+
         if(!is_dir($this->cacheDir)) {
             mkdir($this->cacheDir, 0755);
         }

--- a/src/Engines/ContentEngine.php
+++ b/src/Engines/ContentEngine.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Aschmelyun\Cleaver\Engines;
+
+use Aschmelyun\Cleaver\Compilers\JsonCompiler;
+use Aschmelyun\Cleaver\Compilers\MarkdownCompiler;
+use Aschmelyun\Cleaver\Engines\FileEngine;
+use Tightenco\Collect\Support\Collection;
+
+class ContentEngine
+{
+
+    public static function generateCollection(FileEngine $fileEngine): Collection
+    {
+        $content = [];
+        foreach($fileEngine->getContentFiles() as $contentFile) {
+            $compiler = null;
+            $ext = pathinfo($contentFile, PATHINFO_EXTENSION);
+            switch($ext) {
+                case 'json':
+                    $compiler = new JsonCompiler($contentFile);
+                    break;
+                case 'md':
+                case 'markdown':
+                    $compiler = new MarkdownCompiler($contentFile);
+                    break;
+                default:
+                    break;
+            }
+
+            if($compiler && $compiler->checkFormatting()) {
+                $content[] = $compiler->json;
+            }
+        }
+
+        return new Collection($content);
+    }
+
+}

--- a/tests/ContentEngineTest.php
+++ b/tests/ContentEngineTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use Aschmelyun\Cleaver\Engines\ContentEngine;
+use Aschmelyun\Cleaver\Engines\FileEngine;
+
+class ContentEngineTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function will_return_collection_of_content_files()
+    {
+        $fileEngine = new FileEngine();
+
+        $expected = 'Tightenco\Collect\Support\Collection';
+        $actual = ContentEngine::generateCollection($fileEngine);
+
+        $this->assertInstanceOf($expected, $actual);
+
+        $actual = $actual->count();
+        $expected = 2;
+
+        $this->assertEquals($expected, $actual);
+    }
+
+}

--- a/tests/ContentEngineTest.php
+++ b/tests/ContentEngineTest.php
@@ -21,7 +21,7 @@ class ContentEngineTest extends TestCase
         $this->assertInstanceOf($expected, $actual);
 
         $actual = $actual->count();
-        $expected = 2;
+        $expected = 1;
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/JsonCompilerTest.php
+++ b/tests/JsonCompilerTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Aschmelyun\Cleaver\Compilers\JsonCompiler;
 use Aschmelyun\Cleaver\Engines\FileEngine;
+use Symfony\Component\Finder\SplFileInfo;
 
 class JsonCompilerTest extends TestCase
 {
@@ -18,9 +19,11 @@ class JsonCompilerTest extends TestCase
             'path' => '/',
             'title' => 'This is a test'
         ];
-        $contentFile = 'test.json';
+        $contentFile = FileEngine::contentDir() . 'test.json';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, json_encode($content));
+        file_put_contents($contentFile, json_encode($content));
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new JsonCompiler($contentFile);
 
         $expected = 'layout.test';
@@ -45,9 +48,11 @@ class JsonCompilerTest extends TestCase
             'path' => '/',
             'title' => 'This is a test'
         ];
-        $contentFile = 'test.json';
+        $contentFile = FileEngine::contentDir() . 'test.json';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, json_encode($content));
+        file_put_contents($contentFile, json_encode($content));
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new JsonCompiler($contentFile);
 
         $this->assertFalse($compiler->checkFormatting());
@@ -62,9 +67,11 @@ class JsonCompilerTest extends TestCase
             'view' => 'layout.test',
             'title' => 'This is a test'
         ];
-        $contentFile = 'test.json';
+        $contentFile = FileEngine::contentDir() . 'test.json';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, json_encode($content));
+        file_put_contents($contentFile, json_encode($content));
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new JsonCompiler($contentFile);
 
         $this->assertFalse($compiler->checkFormatting());
@@ -80,9 +87,11 @@ class JsonCompilerTest extends TestCase
             'path' => '/',
             'title' => 'This is a test'
         ];
-        $contentFile = 'test.json';
+        $contentFile = FileEngine::contentDir() . 'test.json';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, json_encode($content));
+        file_put_contents($contentFile, json_encode($content));
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new JsonCompiler($contentFile);
 
         $this->assertTrue($compiler->checkFormatting());

--- a/tests/MarkdownCompilerTest.php
+++ b/tests/MarkdownCompilerTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Aschmelyun\Cleaver\Compilers\MarkdownCompiler;
 use Aschmelyun\Cleaver\Engines\FileEngine;
+use Symfony\Component\Finder\SplFileInfo;
 
 class MarkdownCompilerTest extends TestCase
 {
@@ -22,9 +23,11 @@ class MarkdownCompilerTest extends TestCase
         
         # This is a test
         ';
-        $contentFile = 'test.md';
+        $contentFile = FileEngine::contentDir() . 'test.md';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, $content);
+        file_put_contents($contentFile, $content);
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new MarkdownCompiler($contentFile);
 
         $expected = 'layout.test';
@@ -53,9 +56,11 @@ class MarkdownCompilerTest extends TestCase
         
         # This is a test
         ';
-        $contentFile = 'test.md';
+        $contentFile = FileEngine::contentDir() . 'test.md';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, $content);
+        file_put_contents($contentFile, $content);
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new MarkdownCompiler($contentFile);
 
         $this->assertFalse($compiler->checkFormatting());
@@ -74,9 +79,11 @@ class MarkdownCompilerTest extends TestCase
         
         # This is a test
         ';
-        $contentFile = 'test.md';
+        $contentFile = FileEngine::contentDir() . 'test.md';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, $content);
+        file_put_contents($contentFile, $content);
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new MarkdownCompiler($contentFile);
 
         $this->assertFalse($compiler->checkFormatting());
@@ -96,9 +103,11 @@ class MarkdownCompilerTest extends TestCase
         
         # This is a test
         ';
-        $contentFile = 'test.md';
+        $contentFile = FileEngine::contentDir() . 'test.md';
 
-        file_put_contents(FileEngine::contentDir() . $contentFile, $content);
+        file_put_contents($contentFile, $content);
+
+        $contentFile = new SplFileInfo($contentFile, FileEngine::contentDir(), $contentFile);
         $compiler = new MarkdownCompiler($contentFile);
 
         $this->assertTrue($compiler->checkFormatting());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Aschmelyun\Cleaver\Engines\FileEngine;
+use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -50,12 +51,14 @@ class TestCase extends BaseTestCase
     {
         file_put_contents(self::TEST_VIEW_PATH,'<h1>{{ $title }}</h1>');
 
+        $fileEngine = new FileEngine();
+
         if(!is_dir(FileEngine::outputDir())) {
             mkdir(FileEngine::outputDir() . 'assets/css', 0777, true);
         }
 
-        if(!is_file(FileEngine::MIX_MANIFEST_FILE)) {
-            file_put_contents(FileEngine::MIX_MANIFEST_FILE, json_encode(self::MIX_MANIFEST_TEST_DATA));
+        if(!is_file(FileEngine::mixManifest())) {
+            file_put_contents(FileEngine::mixManifest(), json_encode(self::MIX_MANIFEST_TEST_DATA));
         }
     }
 
@@ -68,8 +71,8 @@ class TestCase extends BaseTestCase
             rmdir(FileEngine::outputDir());
         }
 
-        if(is_file(FileEngine::MIX_MANIFEST_FILE)) {
-            unlink(FileEngine::MIX_MANIFEST_FILE);
+        if(is_file(FileEngine::mixManifest())) {
+            unlink(FileEngine::mixManifest());
         }
 
         if(is_file(FileEngine::contentDir() . 'test.json')) {


### PR DESCRIPTION
This PR adds a pretty decent chunk of features and overall upgrades. Here's what's been added:

- Uses the Symfony Finder package in FileEngine->getContentFiles() instead of scandir. This enables recursive directory searching, ignoring dotfiles, and filtering out just json and markdown files all in one line.
- Adds a basePath variable to the main Cleaver class, enabling nested or differently-organized codebases to access the content/dist directories by modifying a single line.
- Adds a `$content` variable to every single view, containing a Collection (via the tightenco/collect package) that contains all content across the entire site. Allows you to filter/map/sort pages and content previews for something like a latests posts page.