### PR TITLE
Replace assertEquals with assertSame to be strict

### DIFF
--- a/tests/BladeEngineTest.php
+++ b/tests/BladeEngineTest.php
@@ -14,11 +14,11 @@ class BladeEngineTest extends TestCase
     public function can_create_cache_dir_with_write_permissions()
     {
         $bladeEngine = new BladeEngine();
-        $this->assertTrue(is_dir($bladeEngine->cacheDir));
+        $this->assertDirectoryExists($bladeEngine->cacheDir);
 
         $expected = '0755';
         $actual = substr(sprintf('%o', fileperms($bladeEngine->cacheDir)), -4);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -33,7 +33,7 @@ class BladeEngineTest extends TestCase
         $expected = "<h1>This is a test</h1>";
         $actual = $bladeEngine->render($data);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/ContentEngineTest.php
+++ b/tests/ContentEngineTest.php
@@ -23,7 +23,7 @@ class ContentEngineTest extends TestCase
         $actual = $actual->count();
         $expected = 1;
 
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
 }

--- a/tests/JsonCompilerTest.php
+++ b/tests/JsonCompilerTest.php
@@ -28,15 +28,15 @@ class JsonCompilerTest extends TestCase
 
         $expected = 'layout.test';
         $actual = $compiler->json->view;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $expected = '/';
         $actual = $compiler->json->path;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $expected = 'This is a test';
         $actual = $compiler->json->title;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/MarkdownCompilerTest.php
+++ b/tests/MarkdownCompilerTest.php
@@ -32,15 +32,15 @@ class MarkdownCompilerTest extends TestCase
 
         $expected = 'layout.test';
         $actual = $compiler->json->view;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $expected = '/';
         $actual = $compiler->json->path;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $expected = 'This is a test';
         $actual = $compiler->json->title;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
# Changed log

 - Using the `assertDirectoryExists` to assert that expected directory is existed.
- Using the `assertSame` to make assertion equals checking strict.