### PR TITLE
Added parsing of the path allowing for custom output filenames

### DIFF
--- a/src/Engines/FileEngine.php
+++ b/src/Engines/FileEngine.php
@@ -3,7 +3,7 @@
 namespace Aschmelyun\Cleaver\Engines;
 
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Filesystem\Filesystem;
+use Illuminate\Filesystem\Filesystem;
 
 class FileEngine
 {
@@ -51,14 +51,14 @@ class FileEngine
             ->ignoreDotFiles($ignoreDotFiles)
             ->exclude($exclude);
 
-        $filesystem->remove($filesToRemove);
+        $filesystem->delete($filesToRemove);
 
         $directoriesToRemove = $finder->directories()
             ->in(self::$outputDir)
             ->ignoreDotFiles($ignoreDotFiles)
             ->exclude($exclude);
 
-        $filesystem->remove($directoriesToRemove);
+        $filesystem->delete($directoriesToRemove);
     }
 
     public function getContentFiles(): Finder
@@ -81,12 +81,21 @@ class FileEngine
 
     public static function store(string $html, string $path): bool
     {
-        $outputDir = self::$outputDir . $path;
 
-        if(!is_dir($outputDir))
+        $fs = new Filesystem();
+
+        $extension = $fs->extension($path);
+
+        $outputPath = self::$outputDir . $path;
+        if ($fs->extension($path) !== 'html') {
+            $outputPath = $outputDir . '/index.html';
+        }
+
+        $outputDir = $fs->dirname($outputPath);
+
+        if (! is_dir($outputDir)) {
             mkdir($outputDir, 0755, true);
-
-        $outputPath = $outputDir . '/index.html';
+        }
 
         return boolval(file_put_contents($outputPath, $html));
     }


### PR DESCRIPTION
Made the file engine use illuminate filesystem instead of symphony's  and added parsing of the path allowing for custom output filenames if the path uses .html extension.

Example:

```
{
    "view": "layout.default",
    "path": "/blog.html",
    ...
}
```

Would create **dist/blog.html** instead of **dist/blog.html/index.html**.